### PR TITLE
build: make workflow names matchy-matchy

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     deploy:
-        name: Deploy Develop
+        name: Deploy Production
         runs-on: ubuntu-latest
         env:
             AMPT_API_KEY: ${{ secrets.AMPT_API_KEY }}
@@ -19,4 +19,3 @@ jobs:
                 node-version: 18
             - run: npm ci
             - run: npx @ampt/cli deploy prod
-

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     deploy:
-        name: Deploy Develop
+        name: Deploy QA-Test
         runs-on: ubuntu-latest
         env:
             AMPT_API_KEY: ${{ secrets.AMPT_API_KEY }}


### PR DESCRIPTION
Job names weren't matching because copy pasta and big confusion ensued.